### PR TITLE
Compatability issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
         "incentfit/inky": "1.3.6.5",
         "illuminate/support": "^5.7|^6.0",
         "illuminate/view": "^5.7|^6.0",
-        "symfony/css-selector": "^2.7|^3.0|^4.0",
         "symfony/dom-crawler": "^2.7|^3.0|^4.0",
         "tijsverkoyen/css-to-inline-styles": "^2.2"
     },


### PR DESCRIPTION
The `"symfony/css-selector"` library gets pulled in through the `"symfony/dom-crawler"` library allowing for newer ^5.0 versions, which we actually need in order to resolve compatibility issues with RSVPify dependencies.  So requiring this package manually is redundant and currently too outdated as-is.